### PR TITLE
Randomize enemy placement and restore hide control

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,7 +367,8 @@
             invulnerableTime: 0,
             clones: [],
             smokeTime: 0,
-            invisibleTime: 0
+            invisibleTime: 0,
+            shadowBlend: false
         };
 
         // 敵配列
@@ -626,6 +627,7 @@
             player.isInvisible = false;
             player.isHiding = false;
             player.isCrouching = false;
+            player.shadowBlend = false;
             
             console.log('プレイヤー位置設定:', player.x, player.y);
         }
@@ -634,31 +636,41 @@
         function spawnEnemiesForFloor(floorIndex) {
             const floor = floors[floorIndex - 1];
             if (!floor || !floor.enemies) return;
-            
-            floor.enemies.forEach((enemyType, index) => {
+
+            const positions = [];
+            floor.enemies.forEach((enemyType) => {
                 const enemyHeight = enemyType === 'lord' ? 60 : 45;
                 let health = enemyType === 'lord' ? 5 : 1;
                 let speed = 0.5;
-                
+
                 if (enemyType === 'samurai') speed = 1;
                 else if (enemyType === 'spearman') speed = 1.2;
                 else if (enemyType === 'shieldman') { speed = 0.3; health = 2; }
                 else if (enemyType === 'archer') speed = 0.5;
                 else if (enemyType === 'lord') speed = 0;
 
+                let x;
+                let attempts = 0;
+                do {
+                    x = 50 + Math.random() * (canvasWidth - 100);
+                    attempts++;
+                } while (positions.some(p => Math.abs(p - x) < 60) && attempts < 10);
+                positions.push(x);
+
+                const width = enemyType === 'lord' ? 80 : 45;
                 const enemy = {
                     type: enemyType,
-                    x: 50 + (index * 100),
+                    x: x,
                     y: floor.y - enemyHeight,
-                    width: enemyType === 'lord' ? 80 : 45,
+                    width: width,
                     height: enemyHeight,
                     health: health,
                     direction: Math.random() > 0.5 ? 1 : -1,
                     speed: speed,
                     shootTimer: 0,
                     alertLevel: 0,
-                    patrolLeft: 50 + (index * 100) - 50,
-                    patrolRight: 50 + (index * 100) + 50,
+                    patrolLeft: Math.max(0, x - 50),
+                    patrolRight: Math.min(canvasWidth - width, x + 50),
                     awake: false
                 };
                 enemies.push(enemy);
@@ -790,6 +802,10 @@
             if (isInShadow()) {
                 player.isHiding = !player.isHiding;
                 gameState.stealthMode = player.isHiding;
+                player.shadowBlend = player.isHiding;
+            } else {
+                player.isHiding = false;
+                player.shadowBlend = false;
             }
         }
 
@@ -1651,7 +1667,7 @@
                 ctx.stroke();
             }
 
-            if (player.isHiding && isInShadow()) {
+            if (player.isHiding && player.shadowBlend) {
                 ctx.strokeStyle = 'rgba(78, 205, 196, 0.8)';
                 ctx.lineWidth = 2;
                 ctx.strokeRect(player.x - 5, player.y - 5 - gameState.scrollY, player.width + 10, player.height + 10);

--- a/script.js
+++ b/script.js
@@ -361,13 +361,14 @@ function spawnEntitiesForFloor(floorIndex) {
 function spawnEnemiesForFloor(floorIndex) {
     const floor = floors[floorIndex - 1];
     if (!floor) return;
-    
-    floor.enemies.forEach((enemyType, index) => {
+
+    const positions = [];
+    floor.enemies.forEach((enemyType) => {
         const enemyHeight = enemyType === 'lord' ? 60 : 45;
         let health = 1;
         let speed = 0.5;
         let alertness = 1; // 警戒度
-        
+
         // 敵タイプ別パラメータ
         switch(enemyType) {
             case 'samurai':
@@ -394,11 +395,21 @@ function spawnEnemiesForFloor(floorIndex) {
                 break;
         }
 
+        // 配置位置をランダムに決定（重なりを軽減）
+        let x;
+        let attempts = 0;
+        do {
+            x = 50 + Math.random() * (canvasWidth - 100);
+            attempts++;
+        } while (positions.some(p => Math.abs(p - x) < 60) && attempts < 10);
+        positions.push(x);
+
+        const width = enemyType === 'lord' ? 80 : 45;
         const enemy = {
             type: enemyType,
-            x: 50 + (index * 100) + Math.random() * 20,
+            x: x,
             y: floor.y - enemyHeight,
-            width: enemyType === 'lord' ? 80 : 45,
+            width: width,
             height: enemyHeight,
             health: health,
             maxHealth: health,
@@ -408,8 +419,8 @@ function spawnEnemiesForFloor(floorIndex) {
             alertLevel: 0, // 現在の警戒レベル
             alertness: alertness, // 警戒しやすさ
             shootTimer: Math.random() * 60,
-            patrolLeft: 50 + (index * 100) - 50,
-            patrolRight: 50 + (index * 100) + 50,
+            patrolLeft: Math.max(0, x - 50),
+            patrolRight: Math.min(canvasWidth - width, x + 50),
             lastSeen: { x: 0, y: 0 }, // プレイヤーを最後に見た位置
             awake: false, // 殿専用
             stunTime: 0 // 気絶時間


### PR DESCRIPTION
## Summary
- Spread enemies across each floor using randomized spawn positions to avoid clustering
- Fix hide control by updating player shadow blend state and drawing a hide indicator

## Testing
- `node --check script.js`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c5cdce5dc8330bda1039371d2066e